### PR TITLE
Updated the README to remove the instruction to install subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Download or copy'n paste `tss.py` to your server directory that the Tornado proj
 wget https://raw.githubusercontent.com/DERaC-IO/DeracioTSS/f6691d177de800434593cb336f102c1181c73439/tss.py
 ```
 
-If you love `cURL` or `requests`, it's OK. The script requires `questionary` and `subprocess` packages, so install the two with `pip` in your virtual environment.
+If you love `cURL` or `requests`, it's OK. The script requires the `questionary` package, so install it with `pip` in your virtual environment.
 
 ```
-pip install questionary subprocess
+pip install questionary
 ```
 
 Now you are ready to start the script with `python` or `python3`.


### PR DESCRIPTION
The subprocess module is built into Python and need not be installed separately. Trying to install it using pip just gives an error.
subprocess is available by default for all Python versions >= 2.4